### PR TITLE
Admin Mode: restrict registration to teachers

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,34 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authLoginBtn = document.getElementById("auth-login-btn");
+  const authLogoutBtn = document.getElementById("auth-logout-btn");
+  const authUserLabel = document.getElementById("auth-user-label");
+  const authLoggedOut = document.getElementById("auth-logged-out");
+  const authLoggedIn = document.getElementById("auth-logged-in");
+  const adminRequiredNote = document.getElementById("admin-required-note");
+  const usernameInput = document.getElementById("auth-username");
+  const passwordInput = document.getElementById("auth-password");
+
+  function isAdmin() {
+    return !!localStorage.getItem("adminToken");
+  }
+
+  function applyAuthUI() {
+    if (isAdmin()) {
+      authLoggedOut.classList.add("hidden");
+      authLoggedIn.classList.remove("hidden");
+      authUserLabel.textContent = `Logged in as ${localStorage.getItem("adminUser")}`;
+      signupForm.querySelectorAll("input, select, button").forEach((el) => (el.disabled = false));
+      adminRequiredNote.style.display = "inline";
+    } else {
+      authLoggedOut.classList.remove("hidden");
+      authLoggedIn.classList.add("hidden");
+      authUserLabel.textContent = "";
+      signupForm.querySelectorAll("input, select, button").forEach((el) => (el.disabled = true));
+      adminRequiredNote.style.display = "inline";
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -21,21 +49,22 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
+        // Create participants HTML, include delete buttons only for admins
+        let participantsHTML = "<p><em>No participants yet</em></p>";
+        if (details.participants.length > 0) {
+          const items = details.participants
+            .map((email) => {
+              const delBtn = isAdmin()
+                ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                : "";
+              return `<li><span class="participant-email">${email}</span>${delBtn}</li>`;
+            })
+            .join("");
+          participantsHTML = `<div class="participants-section">
               <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No participants yet</em></p>`;
+              <ul class="participants-list">${items}</ul>
+            </div>`;
+        }
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
@@ -56,7 +85,7 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to delete buttons (only exists for admins)
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
@@ -73,13 +102,20 @@ document.addEventListener("DOMContentLoaded", () => {
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
+    if (!isAdmin()) {
+      showError("Admin login required to unregister.");
+      return;
+    }
+
     try {
+      const token = localStorage.getItem("adminToken");
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
         }
       );
 
@@ -117,13 +153,20 @@ document.addEventListener("DOMContentLoaded", () => {
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
+    if (!isAdmin()) {
+      showError("Admin login required to sign up students.");
+      return;
+    }
+
     try {
+      const token = localStorage.getItem("adminToken");
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
         }
       );
 
@@ -157,4 +200,62 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize app
   fetchActivities();
+
+  function showError(msg) {
+    messageDiv.textContent = msg;
+    messageDiv.className = "error";
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+  }
+
+  // Auth handlers
+  if (authLoginBtn) {
+    authLoginBtn.addEventListener("click", async () => {
+      const username = usernameInput.value.trim();
+      const password = passwordInput.value;
+      if (!username || !password) {
+        showError("Enter username and password.");
+        return;
+      }
+      try {
+        const res = await fetch("/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username, password }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          showError(data.detail || "Login failed");
+          return;
+        }
+        localStorage.setItem("adminToken", data.token);
+        localStorage.setItem("adminUser", data.username);
+        applyAuthUI();
+        fetchActivities();
+      } catch (e) {
+        showError("Login failed. Try again.");
+        console.error(e);
+      }
+    });
+  }
+
+  if (authLogoutBtn) {
+    authLogoutBtn.addEventListener("click", async () => {
+      const token = localStorage.getItem("adminToken");
+      try {
+        await fetch("/logout", {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+      } catch (e) {
+        // ignore
+      }
+      localStorage.removeItem("adminToken");
+      localStorage.removeItem("adminUser");
+      applyAuthUI();
+      fetchActivities();
+    });
+  }
+
+  applyAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,17 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-bar">
+        <div id="auth-logged-out">
+          <input id="auth-username" type="text" placeholder="Teacher username" />
+          <input id="auth-password" type="password" placeholder="Password" />
+          <button id="auth-login-btn">Teacher Login</button>
+        </div>
+        <div id="auth-logged-in" class="hidden">
+          <span id="auth-user-label"></span>
+          <button id="auth-logout-btn">Logout</button>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -22,7 +33,7 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Sign Up for an Activity <small id="admin-required-note">(Teachers only)</small></h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    { "username": "teacher1", "password": "password123" },
+    { "username": "teacher2", "password": "secret456" }
+  ]
+}


### PR DESCRIPTION
Implements Admin Mode as described in #5.

- Adds simple teacher auth backed by `src/teachers.json`
- New endpoints: `POST /login`, `POST /logout`
- Protects `POST /activities/{name}/signup` and `DELETE /activities/{name}/unregister` with bearer token
- Frontend: header login/logout UI, disables sign-up when not logged in, hides delete buttons for non-admins

Test notes:
- Login with `teacher1/password123` or `teacher2/secret456`
- After login, sign-up and unregister send Authorization header
- Students (not logged in) can still view activities and participants

Follow-ups:
- Store hashed passwords when persistence is added
- Consider token persistence/expiry and CSRF for non-API flows
